### PR TITLE
Remove duration, post analytics onload

### DIFF
--- a/apps/base/doc_analytics.py
+++ b/apps/base/doc_analytics.py
@@ -1,6 +1,7 @@
 import json
 from django.core import serializers
 import models as M
+import datetime
 
 def get_num_annotations_stats(sid):
 	import db
@@ -108,8 +109,8 @@ def get_page_stats(sid):
 
 def markAnalyticsVisit(uid, o):
 	for id in o:
-		id_source, duration, junk = id.split("|")
-		x = M.AnalyticsVisit(user_id=uid, source_id=id_source, duration=duration, ctime=datetime.datetime.fromtimestamp((o[id]+0.0)/1000))
+		id_source, junk = id.split("|")
+		x = M.AnalyticsVisit(user_id=uid, source_id=id_source, ctime=datetime.datetime.fromtimestamp((o[id]+0.0)/1000))
 		x.save()
 
 # def get_time_on_page(sid):

--- a/apps/base/models.py
+++ b/apps/base/models.py
@@ -279,7 +279,6 @@ class PageSeen(models.Model):
 class AnalyticsVisit(models.Model):
     source              = ForeignKey(Source)
     user                = ForeignKey(User, null=True)
-    duration            = DateTimeField()
     ctime               = DateTimeField(default=datetime.now)
 
 class Landing(models.Model):

--- a/templates/web/source_analytics.html
+++ b/templates/web/source_analytics.html
@@ -30,12 +30,12 @@
     <script>
       // For logging
       window.onload = function() {
-        timeOpened = Date.now();
-      };
-
-      window.onunload = function() {
-        var duration = (Date.now() - timeOpened)/1000; //time in milliseconds
-        jQuery.concierge.logHistory("analytics", {{ source.id }}+"|"+duration+"|"+(new Date()).getTime());
+        var key = {{ source.id }}+"|"+(new Date()).getTime();
+        var payload = {};
+        payload[key]=(new Date()).getTime();
+        NB.pers.call("log_history", {"analytics": payload}, function(callback) {
+          console.log("logged");
+        });
       };
     </script>
     <script type="text/javascript">


### PR DESCRIPTION
- Removes "duration" from the AnalyticsVisit model because of Chrome issue where POST requests sent in the onunload event get canceled. Instead make the post request in the onload event handler.
- Makes a direct call to GLOB to post analytics data to the server, rather than going through concierge.
