### PR TITLE
Replace function that only works with Python 2.7+

### DIFF
--- a/apps/base/doc_analytics.py
+++ b/apps/base/doc_analytics.py
@@ -123,11 +123,11 @@ def get_page_stats(sid):
 		else:
 			p_stat = 0
 		if p in totaltime_stats:
-			tt_stat = totaltime_stats[p]['total_time'].total_seconds()/60
+			tt_stat = totaltime_stats[p]['total_time'].seconds/60
 		else:
 			tt_stat = 0
 		if p in avgtime_stats:
-			at_stat = avgtime_stats[p]['avgtime_per_user'].total_seconds()/60
+			at_stat = avgtime_stats[p]['avgtime_per_user'].seconds/60
 		else:
 			at_stat = 0
 


### PR DESCRIPTION
Removed timedelta.total_seconds() since it requires Python 2.7+, which apparently isn't running on the dev server.
