### PR TITLE
Fix Issue #216: Removed Excess "Empty Comment" labels

### DIFF
--- a/content/modules/dev/buildEmbed.js
+++ b/content/modules/dev/buildEmbed.js
@@ -183,6 +183,26 @@
                        var f = GLOB.pers.store.o.file[id_source];
                        $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                                var m = GLOB.pers.store;
+                               (function(){
+                                 //comment needs to be removed if its parent not null and its location isn't in the locations
+                                 //find all comments whose parents aren't there, put into queue
+                                 //remove locations associated with those values in the queue
+                                 var q = [];
+                                 //get all keys
+                                 var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
+                                 for(var i in P["comments"]){
+                                     var c = P["comments"][i];
+                                     //if comment is not null && its parent is not in the other comments
+                                     if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
+                                      q.push(c); //to be removed
+                                     }
+                                 }
+                                 $.each(q, function(i, v){//remove comments, locations, & seen if applicable
+                                   delete P["seen"][v.ID];
+                                   delete P["locations"][v.ID_location];
+                                   delete P["comments"][v.ID];
+                                 });
+                               })();
                                m.add("seen", P["seen"]);
                                m.add("comment", P["comments"]);
                                m.add("location", P["locations"]);

--- a/content/modules/dev/buildEmbed.js
+++ b/content/modules/dev/buildEmbed.js
@@ -36,9 +36,9 @@
         //TODO: get id_ensemble from cookie or localStorage if available. 
         $.concierge.addConstants({res: 288, scale: 25, QUESTION: 1, STAR: 2 });
         $.concierge.addComponents({
-                notes_loader:    function(P, cb){GLOB.pers.call("getNotes", P, cb);}, 
-                    note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
-                    note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);}
+                notes_loader: function(P, cb){GLOB.pers.__components.notes_loader(P, cb);},
+                note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
+                note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);}
             });   
         GLOB.pers.store = new GLOB.models.Store();
         GLOB.pers.call(
@@ -183,23 +183,6 @@
                        var f = GLOB.pers.store.o.file[id_source];
                        $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                                var m = GLOB.pers.store;
-                               (function(){
-                                 //find all comments whose parents aren't there, put into queue
-                                 var q = [];
-                                 var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
-                                 for(var i in P["comments"]){
-                                     var c = P["comments"][i];
-                                     //if comment is not null && its parent is not in the other comments
-                                     if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
-                                      q.push(c); //to be removed
-                                     }
-                                 }
-                                 $.each(q, function(i, v){//remove comments, locations, & seen if applicable
-                                   delete P["seen"][v.ID];
-                                   delete P["locations"][v.ID_location];
-                                   delete P["comments"][v.ID];
-                                 });
-                               })();
                                m.add("seen", P["seen"]);
                                m.add("comment", P["comments"]);
                                m.add("location", P["locations"]);

--- a/content/modules/dev/buildEmbed.js
+++ b/content/modules/dev/buildEmbed.js
@@ -184,11 +184,8 @@
                        $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                                var m = GLOB.pers.store;
                                (function(){
-                                 //comment needs to be removed if its parent not null and its location isn't in the locations
                                  //find all comments whose parents aren't there, put into queue
-                                 //remove locations associated with those values in the queue
                                  var q = [];
-                                 //get all keys
                                  var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
                                  for(var i in P["comments"]){
                                      var c = P["comments"][i];

--- a/content/ui/admin/init.collage.js
+++ b/content/ui/admin/init.collage.js
@@ -156,7 +156,7 @@ GLOB.pers.init = function(){
         });
     
     $.concierge.addComponents({
-        notes_loader:    function(P, cb){GLOB.pers.call("getNotes", P, cb);}, 
+        notes_loader: function(P, cb){GLOB.pers.__components.notes_loader(P, cb);}, 
         note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
         note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);}
         });   

--- a/content/ui/admin/init.desktop.js
+++ b/content/ui/admin/init.desktop.js
@@ -135,7 +135,7 @@
         });
             
         $.concierge.addComponents({
-            notes_loader:    function(P, cb){GLOB.pers.call("getNotes", P, cb);}, 
+            notes_loader: function(P, cb){GLOB.pers.__components.notes_loader(P, cb);}, 
             note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
             note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);}
         });   

--- a/content/ui/admin/init.pdfviewer.js
+++ b/content/ui/admin/init.pdfviewer.js
@@ -186,6 +186,26 @@
         document.title = $.E(f.title + " ("+f.numpages +" pages)");
         $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                 var m = GLOB.pers.store;
+                (function(){
+                    //comment needs to be removed if its parent not null and its location isn't in the locations
+                    //find all comments whose parents aren't there, put into queue
+                    //remove locations associated with those values in the queue
+                    var q = [];
+                    //get all keys
+                    var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
+                    for(var i in P["comments"]){
+                        var c = P["comments"][i];
+                        //if comment is not null && its parent is not in the other comments
+                        if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
+                            q.push(c); //to be removed
+                        }
+                    }
+                    $.each(q, function(i, v){//remove comments, locations, & seen if applicable
+                        delete P["seen"][v.ID];
+                        delete P["locations"][v.ID_location];
+                        delete P["comments"][v.ID];
+                    });
+                })();
                 m.add("seen", P["seen"]);
                 m.add("comment", P["comments"]);
                 m.add("location", P["locations"]);

--- a/content/ui/admin/init.pdfviewer.js
+++ b/content/ui/admin/init.pdfviewer.js
@@ -187,11 +187,8 @@
         $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                 var m = GLOB.pers.store;
                 (function(){
-                    //comment needs to be removed if its parent not null and its location isn't in the locations
                     //find all comments whose parents aren't there, put into queue
-                    //remove locations associated with those values in the queue
                     var q = [];
-                    //get all keys
                     var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
                     for(var i in P["comments"]){
                         var c = P["comments"][i];

--- a/content/ui/admin/init.pdfviewer.js
+++ b/content/ui/admin/init.pdfviewer.js
@@ -122,7 +122,7 @@
                 set_comment_label: function(P,cb){
                     GLOB.pers.call("set_comment_label", P, cb);
                 },
-                notes_loader:    function(P, cb){GLOB.pers.call("getNotes", P, cb);}, 
+                notes_loader: function(P, cb){GLOB.pers.__components.notes_loader(P, cb);},
                     note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
                     note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);},
                     commentlabels_loader:    function(P, cb){GLOB.pers.call("getCommentLabels", P, cb);}                    
@@ -186,23 +186,6 @@
         document.title = $.E(f.title + " ("+f.numpages +" pages)");
         $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
                 var m = GLOB.pers.store;
-                (function(){
-                    //find all comments whose parents aren't there, put into queue
-                    var q = [];
-                    var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
-                    for(var i in P["comments"]){
-                        var c = P["comments"][i];
-                        //if comment is not null && its parent is not in the other comments
-                        if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
-                            q.push(c); //to be removed
-                        }
-                    }
-                    $.each(q, function(i, v){//remove comments, locations, & seen if applicable
-                        delete P["seen"][v.ID];
-                        delete P["locations"][v.ID_location];
-                        delete P["comments"][v.ID];
-                    });
-                })();
                 m.add("seen", P["seen"]);
                 m.add("comment", P["comments"]);
                 m.add("location", P["locations"]);

--- a/content/ui/admin/init.youtubeviewer.js
+++ b/content/ui/admin/init.youtubeviewer.js
@@ -101,7 +101,7 @@ GLOB.pers.init = function(){
     GLOB.pers.call("getGuestFileInfo", {id_source: GLOB.pers.id_source}, GLOB.pers.createStore, GLOB.pers.on_fileinfo_error );
     $.concierge.addConstants({res: 288, scale: 25, QUESTION: 1, STAR: 2 });
     $.concierge.addComponents({
-        notes_loader:    function(P, cb){GLOB.pers.call("getNotes", P, cb);}, 
+        notes_loader: function(P, cb){GLOB.pers.__components.notes_loader(P, cb);},
         note_creator:    function(P, cb){GLOB.pers.call("saveNote", P, cb);},
         note_editor:    function(P, cb){GLOB.pers.call("editNote", P, cb);}
         });   
@@ -168,23 +168,6 @@ GLOB.pers.createStore = function(payload){
     document.title = $.E(f.title);
     $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
         var m = GLOB.pers.store;
-        (function(){
-            //find all comments whose parents aren't there, put into queue
-            var q = [];
-            var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
-            for(var i in P["comments"]){
-                var c = P["comments"][i];
-                //if comment is not null && its parent is not in the other comments
-                if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
-                    q.push(c); //to be removed
-                }
-            }
-            $.each(q, function(i, v){//remove comments, locations, & seen if applicable
-                delete P["seen"][v.ID];
-                delete P["locations"][v.ID_location];
-                delete P["comments"][v.ID];
-            });
-        })();
         m.add("seen", P["seen"]);
         m.add("comment", P["comments"]);
         m.add("location", P["locations"]);

--- a/content/ui/admin/init.youtubeviewer.js
+++ b/content/ui/admin/init.youtubeviewer.js
@@ -169,11 +169,8 @@ GLOB.pers.createStore = function(payload){
     $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
         var m = GLOB.pers.store;
         (function(){
-            //comment needs to be removed if its parent not null and its location isn't in the locations
             //find all comments whose parents aren't there, put into queue
-            //remove locations associated with those values in the queue
             var q = [];
-            //get all keys
             var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
             for(var i in P["comments"]){
                 var c = P["comments"][i];

--- a/content/ui/admin/init.youtubeviewer.js
+++ b/content/ui/admin/init.youtubeviewer.js
@@ -168,6 +168,26 @@ GLOB.pers.createStore = function(payload){
     document.title = $.E(f.title);
     $.concierge.get_component("notes_loader")( {file:id_source }, function(P){
         var m = GLOB.pers.store;
+        (function(){
+            //comment needs to be removed if its parent not null and its location isn't in the locations
+            //find all comments whose parents aren't there, put into queue
+            //remove locations associated with those values in the queue
+            var q = [];
+            //get all keys
+            var keys = $.map(P["comments"], function(e,i){return Number.parseInt(i);});
+            for(var i in P["comments"]){
+                var c = P["comments"][i];
+                //if comment is not null && its parent is not in the other comments
+                if(c.id_parent !== null && $.inArray(c.id_parent, keys)===-1 ){
+                    q.push(c); //to be removed
+                }
+            }
+            $.each(q, function(i, v){//remove comments, locations, & seen if applicable
+                delete P["seen"][v.ID];
+                delete P["locations"][v.ID_location];
+                delete P["comments"][v.ID];
+            });
+        })();
         m.add("seen", P["seen"]);
         m.add("comment", P["comments"]);
         m.add("location", P["locations"]);


### PR DESCRIPTION
This fix address issue #216 by removing the comments that would unnecessarily make "Empty Comment". Right now the server sends Javascript object in response to `getNotes`. `getNotes` appears to get all comments for a file for the user's permissions level. For admins, all comments are gotten, but for students, comments that are shared with "Instructors and TAs Only" are left out. The issue that causes the "Empty Comment" to be rendered are when an admin replies to the a "Instructors and TAs Only", but makes that comment shared with "The Entire Class". So now these comments are shown as "Empty Comments". 

This fix goes through and removes any comments that are not root comments and whose parent comment is not also in the comments returned. 

This fix is difficult to view because it is removing comments. Will discuss with @karger to determine how to best demo. 
