### PR TITLE
Grunt watch extended

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,11 @@ module.exports = function(grunt) {
     if (serverport !== "80"){
         servername += ":"+serverport;
     }
+    //Global Config for multiple tasks
+    var globalConfig = {
+        js: ['Gruntfile.js', 'grunt.js', 'content/ui/admin/*.js', 'content/modules/dev/*.js'],
+        css: ['content/modules/*.css', 'content/modules/**/*.css', 'content/modules/**/**/*.css', 'content/ui/**/*.css']
+    };
     var addPrefix = function(prefix, names){
         /*
          * given a prefix and an array, returns a new array where each element 
@@ -412,9 +417,10 @@ module.exports = function(grunt) {
     for (i in CSS_TARGETS){
         ALL_TARGETS[i+"_css"] = CSS_TARGETS[i];
     }
-    //    console.log(JSON.stringify(CSS_TARGETS));
+
     // Project configuration.
     grunt.initConfig({
+        globalConfig: globalConfig,
         pkg: grunt.file.readJSON('package.json'),
         meta: {
             banner: '/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %> - ' +
@@ -424,7 +430,7 @@ module.exports = function(grunt) {
                 ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */'
         },
         jshint: {           
-            src: ['Gruntfile.js', 'grunt.js', 'content/ui/admin/*.js', 'content/modules/dev/*.js'], 
+            src: globalConfig.js, 
             options: {
                 globals: {
                     jQuery: false,
@@ -467,24 +473,29 @@ module.exports = function(grunt) {
             }
         },
         watch: {
-            files: ['<config:jshint.src>', 'content/modules/*/*.css'],
-            tasks: ['jshint', 'concat', 'cssmin'],
-            options: {
-                livereload: true,
+            scripts: {
+                files: globalConfig.js,
+                tasks: ['jshint', 'concat'],
+                options: {
+                    livereload: true
+                }
+            },
+            styles: {
+                files: globalConfig.css,
+                tasks: ['cssmin'],
+                options:{
+                    livereload: true
+                }
             }
         },     
         uglify: {}
     });
-    
 
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-contrib-watch');
 
-
-    
-    
     // Default task.
     // grunt.registerTask('default', 'lint qunit concat min');
 //    grunt.registerTask('lint', ['jshint']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
     }
     //Global Config for multiple tasks
     var globalConfig = {
-        js: ['Gruntfile.js', 'grunt.js', 'content/ui/admin/*.js', 'content/modules/dev/*.js'],
+        js: ['Gruntfile.js', 'grunt.js', 'content/ui/admin/*.js', 'content/modules/dev/*.js', "content/modules/{NB,auth,dom,mvc}.js"], //would rather use content/modules/*.js
         css: ['content/modules/*.css', 'content/modules/**/*.css', 'content/modules/**/**/*.css', 'content/ui/**/*.css']
     };
     var addPrefix = function(prefix, names){

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -467,9 +467,12 @@ module.exports = function(grunt) {
             }
         },
         watch: {
-            files: '<config:lint.files>',
-            tasks: 'lint qunit'
-        },        
+            files: ['<config:jshint.src>', 'content/modules/*/*.css'],
+            tasks: ['jshint', 'concat', 'cssmin'],
+            options: {
+                livereload: true,
+            }
+        },     
         uglify: {}
     });
     
@@ -477,6 +480,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 
 
     

--- a/content/modules/NB.js
+++ b/content/modules/NB.js
@@ -9,6 +9,9 @@ License
     MIT License (cf. MIT-LICENSE.txt or http://www.opensource.org/licenses/mit-license.php)
 
  */
+//Suppress warnings for using NB variable 
+/* jshint -W079 */
+/* jshint -W020 */
 var NB;
 
 if (NB && (typeof NB !== "object")){

--- a/content/modules/auth.js
+++ b/content/modules/auth.js
@@ -13,7 +13,7 @@
 (function(GLOB){
     GLOB.auth = {};
     GLOB.auth.set_cookie = function( name, value, expires_year, expires_month, expires_day, path, domain, secure ){
-	var cookie_string = name + "=" + escape ( value );
+	var cookie_string = name + "=" + encodeURI ( value );
     
 	if ( expires_year )  {
 	    var expires = new Date ( expires_year, expires_month, expires_day );
@@ -21,13 +21,13 @@
 	}
 
 	if ( path ){
-	    cookie_string += "; path=" + escape ( path );
+	    cookie_string += "; path=" + encodeURI( path );
 	} else {
 	    cookie_string += "; path=/";
 	}
 
 	if ( domain ){
-	    cookie_string += "; domain=" + escape ( domain );
+	    cookie_string += "; domain=" + encodeURI( domain );
 	}
 	if ( secure ){
 	    cookie_string += "; secure";
@@ -42,7 +42,7 @@
     GLOB.auth.get_cookie = function ( cookie_name ){
 	var results = document.cookie.match ( '(^|;) ?' + cookie_name + '=([^;]*)(;|$)' );
 	if ( results ){
-	    return ( unescape ( results[2] ) );
+	    return ( decodeURI( results[2] ) );
 	}
 	else{
 	    return null;

--- a/content/modules/dom.js
+++ b/content/modules/dom.js
@@ -12,16 +12,16 @@
 (function(GLOB){
     if ("NB$" in window){
 	var $ = NB$;
-    };
+    }
     GLOB.dom = {};
     GLOB.dom.elementItem = function(node, n){ //0-based    
 	var i=0;
 	var child = node.firstChild;
 	while(true){
-	    while (child.nodeType != 1){
+	    while (child.nodeType !== 1){
 		child = child.nextSibling;
 	    }
-	    if (i==n){
+	    if (i===n){
 		return child;
 	    }
 	    else{
@@ -35,7 +35,7 @@
 
     GLOB.dom.firstElement = function(node){
 	var child = node.firstChild;
-	while (child.nodeType != 1){
+	while (child.nodeType !== 1){
 	    child = child.nextSibling;
 	}
 	return child;
@@ -44,7 +44,7 @@
     GLOB.dom.previousElement = function(node){
 	var n = node.previousSibling;
 	while(n){
-	    if (n.nodeType == 1){
+	    if (n.nodeType === 1){
 		return n;
 	    }
 	    else{
@@ -58,7 +58,7 @@
     GLOB.dom.nextElement = function(node){
 	var n = node.nextSibling;
 	while(n){
-	    if (n.nodeType == 1){
+	    if (n.nodeType === 1){
 		return n;
 	    }
 	    else{
@@ -95,13 +95,13 @@
     GLOB.dom.getParams = function(){
 	var s = document.location.search;
 	var params = {};
-	if (s != ""){	
+	if (s !== ""){	
 	    s = s.substring(1);
 	    var a = s.split("&");	
 	    for (var i in a){
 		var pos = a[i].search("=");
 		var len = a[i].length;
-		if (pos != -1){
+		if (pos !== -1){
 		    params[a[i].substring(0,pos)] = a[i].substring(pos+1, len);
 		}
 	    }

--- a/content/modules/mvc.js
+++ b/content/modules/mvc.js
@@ -31,7 +31,7 @@
     GLOB.mvc.model.prototype.unregister = function(obs){
 	var i;
 	for (i in this.observers){
-	    if (this.observers[i] == obs){
+	    if (this.observers[i] === obs){
 		delete this.observers[i];
 		return;
 	    }
@@ -108,17 +108,17 @@
     GLOB.mvc.collection.prototype.modify = function(action, payload, items_fieldname){
 	var i;
 	var items = payload[items_fieldname];
-	if (action == "create"){	
+	if (action === "create"){	
 	    for (i=0;i<items.length;i++){
 		this.items[items[i].id] = items[i];
 	    }
 	}
-	else if (action == "add" || action == "update"){
+	else if (action === "add" || action === "update"){
 	    for (i=0;i<items.length;i++){
 		this.items[items[i].id] = items[i];
 	    }
 	}
-	else if (action == "delete"){
+	else if (action === "delete"){
 	    for (i=0;i<items.length;i++){
 		delete this.items[items[i].id];
 	    }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "test": "grunt qunit"
   },
   "devDependencies": {
+    "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-cssmin": "~0.12.2",
     "grunt-contrib-jshint": "~0.11.2",
-    "grunt-contrib-concat": "~0.5.1"
+    "grunt-contrib-watch": "^0.6.1"
   },
   "dependencies": {
     "execSync": ">= 0.0.0"


### PR DESCRIPTION
This is a pull request builds on PR #229. I wanted to make sure that Grunt watch task watches all the files that are concated and outputted into `content/compiled`, so I would need to include `content/modules/auth.js`, `content/modules/NB.js`, `content/modules/mvc.js` and `content/modules/dom.js`. 
The changes had to made to the files in order for them to pass the jshint tests, such as:
* `dom.js` & `mvc.js` - made changes so that all the equality operators are strict
* `auth.js` - removed deprecated `escape` & `unescape` functions
* `NB.js` - added lines to suppress jshint warnings for using NB variable. 

I would prefer to include these files using the wildcard/blob `content/modules/*.js`, but this includes extra files that throw excessive jshint errors. 