### PR TITLE
Chrome breaks when trying to download file with comma in name

### DIFF
--- a/apps/img/views.py
+++ b/apps/img/views.py
@@ -76,7 +76,7 @@ def serve_doc(req, id_source, annotated=False):
         except UnicodeEncodeError: 
             filename = id_source
         filename = "%s%s%s" % (filename, qual, ".pdf")        
-        response['Content-Disposition'] = "attachment; filename=%s" % (filename, )
+        response['Content-Disposition'] = "attachment; filename=\"%s\"" % (filename, )
         signals.file_downloaded.send("file", req=req, uid=uid, id_source=id_source, annotated=annotated)
         return response
     except Http404: 


### PR DESCRIPTION
On our local nb install, we had a user complain that they couldn't download a file in Chrome. The user had a filename with commas in it - an odd choice, but should be supported. They were getting this error:

ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION

Searching for this error leads to a bug report, see: https://code.google.com/p/chromium/issues/detail?id=103618

By adding quotes around the filename, commas are supported. Additionally, the replacement of spaces with underscores might not be necessary (I didn't test that).