### PR TITLE
Fix server error that occurs when userinfo cookie is not valid JSON

### DIFF
--- a/apps/base/utils_response.py
+++ b/apps/base/utils_response.py
@@ -54,7 +54,10 @@ def getUserId(req):
 
 
 def getUserInfo(req, allow_guest=False, extra_confkey_getter=None): 
-    u_in        = json.loads(urllib.unquote(req.COOKIES.get("userinfo", urllib.quote("{}")))) or {}
+    try:
+        u_in        = json.loads(urllib.unquote(req.COOKIES.get("userinfo", urllib.quote("{}")))) or {}
+    except:
+        u_in        = {}
     ckey        = req.GET.get("ckey") or req.COOKIES.get("ckey", None) or (u_in["ckey"] if "ckey" in u_in else None) or (extra_confkey_getter(req) if extra_confkey_getter is not None else None)
     if ckey is None and allow_guest:         
         ckey = auth.getGuestCkey()

--- a/content/modules/dev/buildEmbed.js
+++ b/content/modules/dev/buildEmbed.js
@@ -271,9 +271,7 @@
           //which confuses the interface
           //see issue #280
           //for now, a hack: if login fails, reset guest status
-          GLOB.auth.set_cookie('userinfo',
-          escape(JSON.stringify(
-          { guest: true })));
+          GLOB.auth.set_cookie('userinfo', JSON.stringify({ guest: true }));
           $('#login_to_nb').remove(); //in case one was already present
           $("<button id='login_to_nb'>Login to NB</button>")
           .appendTo('.nb-widget-header')
@@ -319,7 +317,7 @@
     $.concierge.addListeners(GLOB.pers, {
       successful_login: function (evt) {
         GLOB.auth.set_cookie('ckey', evt.value.ckey);
-        GLOB.auth.set_cookie('userinfo', escape(JSON.stringify(evt.value)));
+        GLOB.auth.set_cookie('userinfo', JSON.stringify(evt.value));
         GLOB.conf.userinfo = evt.value;
         $.L('Welcome TO NB !');
         $('#splash-welcome').parent().remove();


### PR DESCRIPTION
We have been encountering issues with students receiving a Page Unavailable
message (500 error) after clicking on a bookmarklet that adds NB_embed.js to a
page to allow commenting on HTML (e.g., OpenStax textbooks). This error has been
found to occur after the bookmarklet is clicked while viewing NB Desktop, which
alters the userinfo cookie such that it is invalid JSON (because the JSON is
escaped twice — once in buildEmbed.js and once again in the
`GLOB.auth.set_cookie` method — cf. fix in buildEmbed.js) even when decoded from
URL encoded format.

The issue does not appear to persist between browser sessions because the
userinfo cookie indicating that the user is a guest expires after the session
closes. However, clicking on the bookmarklet before logging in can also prevent
the user from logging in.