### PR TITLE
Corrected failing 'NB$' in window tests

### DIFF
--- a/content/modules/buildEmbed.js
+++ b/content/modules/buildEmbed.js
@@ -23,11 +23,11 @@ define(function(require) {
       Notepane        = require('notepane_doc'),
       threadview      = require('threadview'),
       editorview      = require('editorview');
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
 
   var $vp;
   var id_ensemble = null;

--- a/content/modules/docviewHtml5.js
+++ b/content/modules/docviewHtml5.js
@@ -11,11 +11,11 @@ define(function(require) {
 
   var _scrollTimerID = null;
   var _scrollCounter = 0;
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
   var cssApplier = null;
   var lastClicked = { set: [], clicked: null };
 

--- a/content/modules/dom.js
+++ b/content/modules/dom.js
@@ -10,8 +10,9 @@
 */
 
 define(function(require) {
-  if ('NB$' in window) {
-    var $ = NB$;
+  var $=require('jquery');
+  if (NB$) {
+    $ = NB$;
   };
 
   var Dom = {};

--- a/content/modules/files.js
+++ b/content/modules/files.js
@@ -23,10 +23,11 @@ define(function(require) {
   var duplicatewizard = require('duplicatewizard');
   var filterwizard    = require('filterwizard');
   var moment = require('moment');
+  var $ = require('jquery');
 
   //require auth
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   var Files = {};

--- a/content/modules/pers.js
+++ b/content/modules/pers.js
@@ -13,9 +13,10 @@ define(function(require) {
   var Conf          = require('conf');
   var Models        = require('models');
   var concierge     = require('concierge');
+  var $             = require('jquery');
   var jquery_ui     = require('jquery_ui');
 
-  var $ = 'NB$' in window ? NB$ : $;
+  $ = NB$ ? NB$ : $;
 
   // it would be great to use document.currentScript, but it only seems to be supported
   // on firefox for now, so we match by filename.
@@ -34,7 +35,7 @@ define(function(require) {
     currentScript: nb_script[nb_script.length - 1],
     embedded: false,
   };
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
 
   /* trick for browsers that don't support document.activeElement
      adapted from http://ajaxandxml.blogspot.com/2007/11/emulating-activeelement-property-with.html

--- a/content/ui/admin/embedopenid.js
+++ b/content/ui/admin/embedopenid.js
@@ -17,8 +17,8 @@ define(function(require) {
       Conf            = require('conf'),
       Dom             = require('dom');
   //require auth
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   Pers.init = function () {

--- a/content/ui/admin/init.analytics.js
+++ b/content/ui/admin/init.analytics.js
@@ -65,11 +65,11 @@ define(function(require) {
   var Pers = require('pers');
   var img_server = Pers.server_url;
 
-  if ('NB$' in window) {
+  if (NB$) {
     $ = NB$;
   }
 
-  $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
 
   Pers.createStore = function () {
     Pers.store = new Models.Store();

--- a/content/ui/admin/init.collage.js
+++ b/content/ui/admin/init.collage.js
@@ -30,8 +30,8 @@ define(function(require) {
       threadview      = require('threadview'),
       editorview      = require('editorview');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   Pers.init = function () {

--- a/content/ui/admin/init.confirm_invite.js
+++ b/content/ui/admin/init.confirm_invite.js
@@ -18,6 +18,7 @@ define(function(require) {
   var Pers            = require('pers');
   var Handlebars 	= require('handlebars');
   var concierge       = require('concierge');
+  var $               = require('jquery');
   var invitekey = window.location.href.split(document.location.pathname + "?invite_key=")[1];
   if (typeof invitekey === 'undefined'){
     invitekey = "";
@@ -25,8 +26,8 @@ define(function(require) {
 
   var form = null;
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   function cb(data, status){

--- a/content/ui/admin/init.desktop.js
+++ b/content/ui/admin/init.desktop.js
@@ -30,11 +30,11 @@ define(function(require) {
   var files           = require('files');
   var Handlebars      = require('handlebars');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$  ? 'NB$' : 'jQuery';
 
   Pers.init = function () {
 

--- a/content/ui/admin/init.enteryourname.js
+++ b/content/ui/admin/init.enteryourname.js
@@ -18,10 +18,11 @@ define(function(require) {
   var Pers            = require('pers');
   var Handlebars 	= require('handlebars');
   var concierge       = require('concierge');
+  var $               = require('jquery');
   var ckey = window.location.href.split(document.location.pathname + "?ckey=")[1];
   var url = "/user_name_form?ckey=" + ckey;
 
-  if ('NB$' in window) {
+  if (NB$) {
     var $ = NB$;
   }
 

--- a/content/ui/admin/init.pdfviewer.js
+++ b/content/ui/admin/init.pdfviewer.js
@@ -26,12 +26,13 @@ define(function(require) {
   var threadview      = require('threadview');
   var editorview      = require('editorview');
   var Handlebars      = require('handlebars');
+  var $               = require('jquery');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
-  var $str = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str = NB$  ?  'NB$' : 'jQuery';
 
   Pers.init = function () {
 

--- a/content/ui/admin/init.spreadsheet.js
+++ b/content/ui/admin/init.spreadsheet.js
@@ -30,8 +30,8 @@ define(function(require) {
       editorview      = require('editorview'),
       spreadsheetview = require('spreadsheetview');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   Pers.init = function () {

--- a/content/ui/admin/init.youtubeviewer.js
+++ b/content/ui/admin/init.youtubeviewer.js
@@ -28,11 +28,11 @@ define(function(require) {
       notepaneview    = require('notepane_video'),
       threadview      = require('threadview');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
 
   Pers.init = function () {
     var matches = document.location.pathname.match(/\/(\d*)$/);

--- a/content/ui/admin/your_settings.js
+++ b/content/ui/admin/your_settings.js
@@ -19,8 +19,8 @@ define(function(require) {
   var Handlebars 	= require('handlebars');
   var concierge       = require('concierge');
 
-  if ('NB$' in window) {
-    var $ = NB$;
+  if (NB$) {
+    $ = NB$;
   }
 
   Pers.init = function () {

--- a/content/views/ui.duplicatewizard.js
+++ b/content/views/ui.duplicatewizard.js
@@ -10,7 +10,7 @@ define(function(require) {
       view            = require('view'),
       $               = require('jquery');
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _create: function () {
       $.ui.view.prototype._create.call(this);

--- a/content/views/ui.editorview.js
+++ b/content/views/ui.editorview.js
@@ -24,7 +24,7 @@ define(function(require) {
 	var rangySelectionSaveRestore = require('rangy-selectionsaverestore');
 	var class_members = [];
 
-	var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+	var $str        = NB$ ? 'NB$' : 'jQuery';
 	var FILETYPES = { TYPE_PDF: 1, TYPE_YOUTUBE: 2, TYPE_HTML5VIDEO: 3, TYPE_HTML5: 4 };
 	var V_OBJ = $.extend({}, $.ui.view.prototype, {
 		_create: function () {

--- a/content/views/ui.filesview.js
+++ b/content/views/ui.filesview.js
@@ -21,7 +21,7 @@ define(function(require) {
   var calendrical = require('calendrical');
   var moment = require('moment');
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _create: function () {
       $.ui.view.prototype._create.call(this);

--- a/content/views/ui.filterwizard.js
+++ b/content/views/ui.filterwizard.js
@@ -10,7 +10,7 @@ define(function(require) {
       view            = require('view'),
       $               = require('jquery');
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _create: function () {
       $.ui.view.prototype._create.call(this);

--- a/content/views/ui.filterwizardEmoticon.js
+++ b/content/views/ui.filterwizardEmoticon.js
@@ -10,7 +10,7 @@ define(function(require) {
       view            = require('view'),
       $               = require('jquery');
 
-  var $str        = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str        = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _create: function () {
       $.ui.view.prototype._create.call(this);

--- a/content/views/ui.notepaneView.doc.js
+++ b/content/views/ui.notepaneView.doc.js
@@ -20,7 +20,7 @@ define(function(require) {
       filterwizard    = require('filterwizard');
       filterwizardEmoticon    = require('filterwizardEmoticon');
 
-  var $str = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _f_location_seen: function (id_location) {
       var self = this;

--- a/content/views/ui.notepaneView.video.js
+++ b/content/views/ui.notepaneView.video.js
@@ -20,7 +20,7 @@ define(function(require) {
       contextmenu     = require('contextmenu'),
       filterwizard    = require('filterwizard');
 
-  var $str     = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str     = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _f_location_seen: function (id_location) {
       var self = this;

--- a/content/views/ui.threadselect.js
+++ b/content/views/ui.threadselect.js
@@ -12,7 +12,7 @@ define(function(require) {
       jquery_ui       = require('jquery_ui'),
       models          = require('models');
 
-  var $str = 'NB$' in window ? 'NB$' : 'jQuery';
+  var $str = NB$ ? 'NB$' : 'jQuery';
   var V_OBJ = $.extend({}, $.ui.view.prototype, {
     _create: function () {
       $.ui.view.prototype._create.call(this);


### PR DESCRIPTION
We've allowed for override of jquery by checking for presence of a
global NB$ variable.  But recently we've wrapped our code in a
function() {} body for isolation.  But now that NB$ is a *local*
variable, our "in window" test fails. I've replaced those tests with
tests for whether NB$ is defined (as a local variable).