### PR TITLE
Add ability to directly add users to ensemble

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,7 +87,8 @@ If you include a Youtube video URL as a class resource, nb will not be able to r
 
 ```
     cd apps
-    ./manage.py makemigrations # to create the database migrations files
+    ./manage.py makemigrations base
+    ./manage.py makemigrations polls # to create the database migrations files
     ./manage.py migrate # To create the database tables from the migrations files
     ./manage.py sqlcustom base | ./manage.py dbshell # to create custom views. If this throws an error, you could simply log in to your postgres database and run the query contained in https://github.com/nbproject/nbproject/blob/dev/apps/base/sql/ensemble.sql 
 ```

--- a/apps/base/auth.py
+++ b/apps/base/auth.py
@@ -154,6 +154,12 @@ def addUser(email, password, conf, valid=0, guest=0):
         gh.save()
     return o
 
+def addToEnsemble(id_user, id_ensemble, id_section, admin):
+    if id_section == 'None':
+        membership = M.Membership(user_id=id_user, ensemble_id=id_ensemble, admin=admin)
+    else:
+        membership = M.Membership(user_id=id_user, ensemble_id=id_ensemble, section_id=id_section, admin=admin)
+    membership.save()
 
 def addInvite(key, id_user, id_ensemble, id_section, admin):
     if id_section == 'None':

--- a/apps/rpc/views.py
+++ b/apps/rpc/views.py
@@ -143,6 +143,7 @@ def sendInvites(payload, req):
     id_ensemble = payload["id_ensemble"]
     id_section = payload.get("id_section", None)
     admin = 0 if "admin" not in payload else payload["admin"]
+    direct = True if "direct" not in payload else payload["direct"]
     if not auth.canSendInvite(uid,id_ensemble):
         return UR.prepare_response({}, 1,  "NOT ALLOWED")
     #extract emails in a somewhat robust fashion (i.e. using several possible delimiters)
@@ -157,6 +158,9 @@ def sendInvites(payload, req):
     for email in emails:
         user = auth.user_from_email(email)
         password=""
+        if user is not None and direct:
+            auth.addToEnsemble(user.id, id_ensemble, id_section, admin)
+            return UR.prepare_response({"msg": "%s added to %s" % (emails, ensemble.name,)})
         if user is None:
             ckey = "".join([ random.choice(string.ascii_letters+string.digits) for i in xrange(0,32)])
             password = "".join([ random.choice(string.ascii_letters+string.digits) for i in xrange(0,4)])

--- a/content/modules/files.js
+++ b/content/modules/files.js
@@ -257,8 +257,9 @@ define(function(require) {
           var to = $('#invite_users_emails')[0].value;
           var msg = $('#invite_users_msg')[0].value;
           var admin = $('#invite_users_admin:checked').length;
+          var direct = $('#invite_users_direct:checked').length == 1 ? true : false;
           var section = $('#invite_users_section').val();
-          $.concierge.get_component('invite_users')({ id_ensemble: id_ensemble, id_section: section, to: to, msg: msg, admin: admin }, function () {$.I('Your invitation has been sent !');});
+          $.concierge.get_component('invite_users')({ id_ensemble: id_ensemble, id_section: section, to: to, msg: msg, admin: admin, direct: direct }, function () {$.I('Your invitation has been sent !');});
 
           $(this).dialog('destroy');
         },

--- a/templates/handlebars/invite_users_dialog.hbs
+++ b/templates/handlebars/invite_users_dialog.hbs
@@ -13,6 +13,9 @@
   <br/>
   <input type='checkbox' id='invite_users_admin' style='padding-left: 20px' />
   <label for='invite_users_admin'>Grant administrative rights to these users</label>
+  <br />
+  <input type='checkbox' id='invite_users_direct' style='padding-left: 20px' />
+  <label for='invite_users_direct'>Add users directly (don't send e-mail if user already exists)</label>
   <br/>
   <br/>
   <p class='fixdialog' ><em>Optional</em> Add a personal message (will appear on the invitation)</p>


### PR DESCRIPTION
We had issues last quarter with making sure students were added to all the ensembles we used for a course because they had to find several emails and accept invitations from all of them or (later) use a subscription link with which to add themselves.

This commit adds a checkbox in the invite_users_dialog for ensemble administrators to directly add students to ensembles without requiring further action from the students (after verifying their email address and entering their name). Emails are still sent if the user does not already exist, regardless of whether or not the checkbox is checked.