### PR TITLE
Remove email and plaintext password from welcome email

### DIFF
--- a/templates/email/confirm_guest_registration
+++ b/templates/email/confirm_guest_registration
@@ -4,10 +4,6 @@ Congratulations ! You've successfully created your account on NB...
 
 - To start using NB, please visit {{conf_url}}
 
-- Please keep the information below, so that you can login in the future: 
-  Your email:	 {{email}}  
-  Your password:   {{password}}
-
 - For a quick tutorial on how to use NB please visit {{tutorial_url}}. 
 
 NB is an communal annotation engine: it lets you read PDF documents and discuss them with other users. 


### PR DESCRIPTION
Fixes #370 

Passwords should not be sent via email in plaintext. This pull request removes the email and password from the welcome email completely.